### PR TITLE
Assorted improvements including IP Intel service added

### DIFF
--- a/README
+++ b/README
@@ -25,6 +25,7 @@ For now, it supports:
 * http://www.stopforumspam.com - the Stop Forum Spam service
 * http://www.projecthoneypot.org/ - The Honeypot Project
 * http://www.akismet.com - The comment spam service from Wordpress
+* https://getipintel.net/ - IP Intel
 
 
 ************ Configuration **************
@@ -36,6 +37,8 @@ $GLOBALS['honeyPotApiKey'] = 'abcdefghij'; ## Your Key from the Honeypot Project
 $GLOBALS['akismetApiKey']  = 'abcdefghij'; ## Your Key from the Akismet Service
 $GLOBALS['akismetBlogURL'] = 'http://yoursite.com'; ## Your website URL
 $GLOBALS['logRoot']        = '/tmp';       ## Where to write logfiles
+$GLOBALS['ipIntelContact'] = 'you@example.com';	## Your e-mail (enables IP Intel)
+$GLOBALS['sfsEnabled'] = true;  ## Set false to disable Stop Forum Spam check (defaults to true (enabled))
 
 ## to avoid overloading the API services, use a memcached service
 ## calls will be cached for a day

--- a/botbouncer.php
+++ b/botbouncer.php
@@ -55,6 +55,7 @@ class Botbouncer {
 
   /** var LE - line ending */
   private $LE = "\n";
+  private $sfsEnabled = true;
   private $honeyPotApiKey = '';
   private $akismetApiKey = '';
   private $akismetBlogURL = 'http://www.yoursite.com';
@@ -71,6 +72,10 @@ class Botbouncer {
   private $startTime = 0;
   private $mollomCheck = '';
   private $mollomEnabled = false;
+  private $ipIntelEnabled = false;
+  private $ipIntelAPIUrl = 'http://check.getipintel.net/check.php';
+  private $ipIntelContact = ''; // IP Intel requires a contact e-mail address
+  private $ipIntelSpamThreshold = 0.99; // Per API's recommendation for automated systems
 
   /**
    * (array) matchDetails - further details on a match provided by SFS
@@ -100,6 +105,7 @@ class Botbouncer {
     'HP' => 'Honeypot Project',
     'AKI' => 'Akismet',
     'MOL' => 'Mollom',
+    'IPI' => 'IP Intel'
   );
   
   private $sfsSpamTriggers = array ( ## set a default, in case it's not in config
@@ -147,10 +153,11 @@ class Botbouncer {
    * @param string $hpKey - API key for Honeypot Project
    * @param string $akismetKey - API key for Akismet service
    * @param string $akismetUrl - BlogURL for Akismet service
+   * @param string $ipIntelContact - Contact email for IP Intel
    *
    */
 
-  public function __construct($hpKey = '',$akismetKey = '',$akismetUrl = '', $mollomPrivateKey = '',$mollomPublicKey = '') {
+  public function __construct($hpKey = '',$akismetKey = '',$akismetUrl = '', $mollomPrivateKey = '',$mollomPublicKey = '', $ipIntelContact = '') {
     if (!function_exists('curl_init')) {
       print 'curl dependency error';
       return;
@@ -178,12 +185,22 @@ class Botbouncer {
     } elseif (!empty($_SERVER['HTTP_HOST'])) {
       $this->akismetBlogURL = $_SERVER['HTTP_HOST'];
     }
-    
+    if (!empty($ipIntelContact)) {
+        $this->ipIntelContact = $ipIntelContact;
+        $this->ipIntelEnabled = true;
+    } elseif (!empty($GLOBALS['ipIntelContact'])) {
+        $this->ipIntelContact = $GLOBALS['ipIntelContact'];
+        $this->ipIntelEnabled = true;
+    } 
+
     if (!empty($GLOBALS['logRoot']) && is_writable($GLOBALS['logRoot'])) {
       $this->logRoot = $GLOBALS['logRoot'];
     }
     if (isset($GLOBALS['ForumSpamBanTriggers'])) {
       $this->spamTriggers = $GLOBALS['ForumSpamBanTriggers'];
+    }
+    if (isset($GLOBALS['sfsEnabled'])) {
+      $this->sfsEnabled = (bool) $GLOBALS['sfsEnabled'];
     }
 
     if (isset($GLOBALS['memCachedServer']) && class_exists('Memcached', false)) {
@@ -755,6 +772,65 @@ class Botbouncer {
     return $isSfsSpam;
   }
 
+  /**
+   * ipIntelCheck - check with IP Intel Database API
+   * @param string $ip -- IP to check.  If null, will try to pull from $_SERVER vars
+   * @return boolean If within bad IP detection threshold.
+   */
+  function ipIntelCheck($ip) {
+      
+    if ((!isset($ip) || $ip == "") && isset($_SERVER['REMOTE_ADDR'])) {
+      $ip = $_SERVER['REMOTE_ADDR'];
+      if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+        $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+      }
+    }
+
+    $this->dbg('IPI check');
+    $this->addLogEntry('ipi-apicall.log','IPI Check on ' . $ip);
+
+    $resultNumeric = null;
+    $cached = $this->getCache('IPI'.$ip);
+    if (!$cached) {
+      $cUrl = $this->ipIntelAPIUrl . '?ip=' . urlencode($ip) . '&contact=' . urlencode($this->ipIntelContact);
+      $this->addLogEntry('ipi-apicall.log',$cUrl);
+      $resultString = $this->doGET($cUrl);
+
+      if (!is_numeric($resultString))
+      {
+        $this->addLogEntry('ipi-apicall.log','API returned non-number');
+        return false;
+      } 
+
+      $resultNumeric = (float) $resultString;
+
+      if ($resultNumeric < 0) {
+        $this->addLogEntry('ipi-apicall.log','API returned error code: ' . $resultNumeric);
+        return false;
+      }
+
+      $this->setCache('IPI'.$ip,$resultNumeric);
+      $cached = ''; // for logging
+    } else {
+      $resultNumeric = $cached;
+      $cached = '(cached)'; // for logging
+    }
+
+    if (is_null($resultNumeric) || $resultNumeric < 0 || $resultNumeric > 1)
+    {
+        $this->addLogEntry('ipi-apicall.log','API or cache returned out of bounds result: ' . $resultNumeric);
+        return false;
+    }
+
+    if ($resultNumeric > $this->ipIntelSpamThreshold)
+    {
+        $this->dbg('SFS check SPAM');
+        $this->addLogEntry('ipi-apicall.log','SPAM IP detected: ' . $ip . ' --- score is: ' . $resultNumeric);
+        return true;
+    }
+      return false;
+  }
+
 
   /**
    * isSpam - match submission against spam protection sources
@@ -817,7 +893,7 @@ class Botbouncer {
         $this->addLogEntry('munin-graph.log','HPHAM');
       }
     }
-    if ((!$isSpam || $checkAll)) {
+    if ((!$isSpam || $checkAll) && $this->sfsEnabled) {
       $num = $this->stopForumSpamCheck($data);
       if ($num) {
         $this->matchedBy = 'Stop Forum Spam';
@@ -852,6 +928,35 @@ class Botbouncer {
         $this->addLogEntry('munin-graph.log','MOLHAM');
       }
     }
+
+    if ((!$isSpam || $checkAll) && $this->ipIntelEnabled) {
+
+        $isIPIntelSpam = false;
+        if (empty($data['ips']))
+        {
+            if ($this->ipIntelCheck('')) // Will attempt to use HTTP Headers
+            {
+                $isIPIntelSpam = true;
+            }
+        } else {
+            foreach ($data['ips'] as $ip) {
+                if ($this->ipIntelCheck($ip))
+                {
+                    $isIPIntelSpam = true;
+                }
+            }
+        }
+
+        if ($isIPIntelSpam)
+        {
+            $this->matchedBy = 'IP Intel';
+            $servicesMatched[] = 'IPI';
+            $isSpam++;
+            $this->addLogEntry('munin-graph.log','IPISPAM');
+        } else {
+            $this->addLogEntry('munin-graph.log','IPIHAM');
+        }
+      }
 
     ## to test the comparison code below
 /*

--- a/tests.php
+++ b/tests.php
@@ -17,7 +17,7 @@ $spam = array (
 );
 
 $ham = array (
-  'ips' => array('77.240.14.92'),
+  'ips' => array('132.67.70.2'),
   'user_agent' => 'Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; rv:1.9.2.20) Gecko/20110803 Firefox/3.6.20',
   'referrer' => 'http://wordpress.com',
   'username' => 'HelloWorld',
@@ -31,7 +31,7 @@ I think this story helps illustrate the difference between PMD and all of the ot
 );
 
 $minimalham = array (
-  'ips' => array('77.240.14.92'),
+  'ips' => array('132.67.70.2'),
   'username' => 'HelloWorld',
   'email' => 'phplist@gmail.com',
 );
@@ -39,7 +39,7 @@ $minimalham = array (
 
 $fsc = new Botbouncer();
 $fsc->setDebug(false);
-print "SFS\n";
+print "SFS:\n";
 if ($fsc->stopForumSpamCheck($spam)) {
   print "SPAM\n";
 } else {
@@ -53,8 +53,9 @@ if ($fsc->stopForumSpamCheck($minimalham)) {
   print "HAM\n";
 }
 #var_dump($fsc->matchDetails);
+print "\n";
 
-print 'Akismet'."\n";
+print 'Akismet:'."\n";
 if ($fsc->akismetCheck($spam)) {
   print "SPAM\n";
 } else {
@@ -65,7 +66,9 @@ if ($fsc->akismetCheck($minimalham)) {
 } else {
   print "HAM\n";
 }
-print 'Honeypot'."\n";
+print "\n";
+
+print 'Honeypot:'."\n";
 if ($fsc->honeypotcheck($spam['ips'][0])) {
   print "SPAM\n";
 } else {
@@ -76,16 +79,31 @@ if ($fsc->honeypotcheck($minimalham['ips'][0])) {
 } else {
   print "HAM\n";
 }
-print 'Generic'."\n";
-if ($fsc->isSpam($spam)) {
+print "\n";
+
+print 'IP Intel:'."\n";
+if ($fsc->ipIntelCheck($spam['ips'][1])) {
   print "SPAM\n";
+} else {
+  print "HAM\n";
+}
+if ($fsc->ipIntelCheck($minimalham['ips'][0])) {
+  print "SPAM\n";
+} else {
+  print "HAM\n";
+}
+print "\n";
+
+print 'Generic:'."\n";
+if ($fsc->isSpam($spam)) {
+  print "SPAM:  ";
   print $fsc->matchedBy."\n";
 } else {
   print "HAM\n";
 }
 
 if ($fsc->isSpam($minimalham)) {
-  print "SPAM\n";
+  print "SPAM:  ";
   print $fsc->matchedBy."\n";
 } else {
   print "HAM\n";


### PR DESCRIPTION
Figured I should send these over as they might be handy.  Feel free to grab any or all of these (I was originally sending these atomically, but sent to the wrong place and now I'm out of time, so sorry to send them in a big batch)

**Support for IP Intel service added**
	This pull request adds optional support for IP Intel service.  I've been getting some spam registrations lately, and this service seems to catch more of them (so far, at least).

**Allow stopforumspam to be disabled**
	For me, SFS wasn't catching anything and I didn't really want to share user e-mails externally. So now I added option to disable SFS for people who want to choose which services to check.

**Tests added for IP Intel + Test output more readable**
	(FYI all the other non-IP Intel tests were/are failing even before this change)

**IP Test Update**
Test ham IP is one that is flagged as 'low risk proxy connection' by ipqualityscore, so I changed to a random cleaner one

**Update README with new options + IP Intel**